### PR TITLE
NavigationParams: any type of param

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -236,7 +236,7 @@ export type NavigationNavigator<T> = React.ComponentClass<T> & {
 }
 
 export type NavigationParams = {
-  [key: string]: string,
+  [key: string]: any,
 }
 
 export type NavigationNavigateAction = {


### PR DESCRIPTION
Add ability to do this : 
```typescript
goToCar = (carId: number) => {
    const actionToDispatch = NavigationActions.navigate({
        routeName,
        params: {carId}
    });
    this.props.navigation.dispatch(actionToDispatch);
}
```
That wasn't possible before because params accepted only string as value.